### PR TITLE
Gitattributes: to keep LF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+*               text=auto
+*.txt           text
+*.env           text eol=lf
+*.sample        text eol=lf


### PR DESCRIPTION
LF line endings in env files are required for cygwin to process the files correctly