### PR TITLE
- Implemented: removed defined storage class for AWS, added comments

### DIFF
--- a/ods-configuration.env.sample
+++ b/ods-configuration.env.sample
@@ -60,11 +60,14 @@ OPENSHIFT_APPS_BASEDOMAIN=.192.168.99.100.nip.io
 # Storage class for volumes #
 #############################
 
-# the storage class provisioner 
-STORAGE_PROVISIONER=kubernetes.io/aws-ebs
+# the storage class provisioner
+# for AWS kubernetes.io/aws-ebs
+STORAGE_PROVISIONER=""
 
 # storage class for data
-STORAGE_CLASS_DATA=gp2
+# for AWS gp2
+STORAGE_CLASS_DATA=""
 
 # storage class for data backup
-STORAGE_CLASS_BACKUP=gp2-encrypted
+# for AWS gp2-encrypted
+STORAGE_CLASS_BACKUP=""

--- a/ods-core/nexus/ocp-config/pvc.env.sample
+++ b/ods-core/nexus/ocp-config/pvc.env.sample
@@ -1,8 +1,13 @@
 # Nexus setup
 
-# the storage class provisioner 
-STORAGE_PROVISIONER=kubernetes.io/aws-ebs
+# the storage class provisioner
+# for AWS kubernetes.io/aws-ebs
+STORAGE_PROVISIONER=""
+
 # storage class for data
-STORAGE_CLASS_DATA=gp2
+# for AWS gp2
+STORAGE_CLASS_DATA=""
+
 # storage class for data backup
-STORAGE_CLASS_BACKUP=gp2-encrypted
+# for AWS gp2-encrypted
+STORAGE_CLASS_BACKUP=""

--- a/ods-core/sonarqube/ocp-config/sonarqube.env.sample
+++ b/ods-core/sonarqube/ocp-config/sonarqube.env.sample
@@ -23,11 +23,14 @@ DATABASE_USER=sonarqube
 # Host without protocol exposed by the sonarqube route
 SONARQUBE_HOST=sonarqube-cd.192.168.99.100.nip.io
 
-# the storage class provisioner 
-STORAGE_PROVISIONER=kubernetes.io/aws-ebs
+# the storage class provisioner
+# for AWS kubernetes.io/aws-ebs
+STORAGE_PROVISIONER=""
 
 # storage class for data
-STORAGE_CLASS_DATA=gp2
+# for AWS gp2
+STORAGE_CLASS_DATA=""
 
 # storage class for data backup
-STORAGE_CLASS_BACKUP=gp2-encrypted
+# for AWS gp2-encrypted
+STORAGE_CLASS_BACKUP=""

--- a/ods-project-quickstarters/ocp-templates/templates/templates.env.sample
+++ b/ods-project-quickstarters/ocp-templates/templates/templates.env.sample
@@ -11,11 +11,14 @@ CD_USER_PWD=changeme_base64
 
 # Nexus URL exposed by the nexus route
 NEXUS_URL=https://nexus-cd.192.168.99.100.nip.io
+NEXUS_USERNAME=developer
+NEXUS_PASSWORD=changeme_base64
 
 # Sonarqube URL exposed by the sonarqube route
 SONARQUBE_URL=https://sonarqube-cd.192.168.99.100.nip.io
 SONAR_SERVER_AUTH_TOKEN=changme_base64
-DOCKER_REGISTRY=docker-registry.default.svc:5000
+# DNS service name for Openshift > 3.9.6 docker-registry.default.svc
+DOCKER_REGISTRY=172.30.1.1:5000
 
 # Configuration for rshiny quickstarter
 
@@ -25,3 +28,5 @@ CROWD_RSHINY_REALM_NAME=Shiny Test
 CROWD_RSHINY_REALM_USER=rshiny_base64
 CROWD_RSHINY_REALM_PW=changeme_base64
 
+# Bitbucket host
+BITBUCKET_HOST=192.168.56.31:7990

--- a/ods-provisioning-app/ocp-config/prov-cd/pvc.env.sample
+++ b/ods-provisioning-app/ocp-config/prov-cd/pvc.env.sample
@@ -1,10 +1,13 @@
 # Provision app setup
 
-# the storage class provisioner 
-STORAGE_PROVISIONER=kubernetes.io/aws-ebs
+# the storage class provisioner
+# for AWS kubernetes.io/aws-ebs
+STORAGE_PROVISIONER=""
 
 # storage class for data
-STORAGE_CLASS_DATA=gp2
+# for AWS gp2
+STORAGE_CLASS_DATA=""
 
 # storage class for data backup
-STORAGE_CLASS_BACKUP=gp2-encrypted
+# for AWS gp2-encrypted
+STORAGE_CLASS_BACKUP=""

--- a/ods-provisioning-app/ocp-config/prov-dev/pvc.env.sample
+++ b/ods-provisioning-app/ocp-config/prov-dev/pvc.env.sample
@@ -1,10 +1,13 @@
 # Provision app setup
 
-# the storage class provisioner 
-STORAGE_PROVISIONER=kubernetes.io/aws-ebs
+# the storage class provisioner
+# for AWS kubernetes.io/aws-ebs
+STORAGE_PROVISIONER=""
 
 # storage class for data
-STORAGE_CLASS_DATA=gp2
+# for AWS gp2
+STORAGE_CLASS_DATA=""
 
 # storage class for data backup
-STORAGE_CLASS_BACKUP=gp2-encrypted
+# for AWS gp2-encrypted
+STORAGE_CLASS_BACKUP=""

--- a/ods-provisioning-app/ocp-config/prov-test/pvc.env.sample
+++ b/ods-provisioning-app/ocp-config/prov-test/pvc.env.sample
@@ -1,10 +1,13 @@
 # Provision app setup
 
-# the storage class provisioner 
-STORAGE_PROVISIONER=kubernetes.io/aws-ebs
+# the storage class provisioner
+# for AWS kubernetes.io/aws-ebs
+STORAGE_PROVISIONER=""
 
 # storage class for data
-STORAGE_CLASS_DATA=gp2
+# for AWS gp2
+STORAGE_CLASS_DATA=""
 
 # storage class for data backup
-STORAGE_CLASS_BACKUP=gp2-encrypted
+# for AWS gp2-encrypted
+STORAGE_CLASS_BACKUP=""


### PR DESCRIPTION
The AWS specific definitions have been removed. Minishift does not provide different storage types, so the default value is empty