### PR TITLE
Add pipeline params

### DIFF
--- a/ods-provisioning-app/ocp-config/prov-cd/bc.env.sample
+++ b/ods-provisioning-app/ocp-config/prov-cd/bc.env.sample
@@ -1,4 +1,7 @@
 # Provision app setup
 
-# GIT repository url pointing to the provision app
-PROV_APP_REPO_URL=https://github.com/opendevstack/ods-core.git
+# repository base url. In case bitbucket is used, needs to include /scm - so it's the path in front on opendevstack/..
+REPO_BASE=https://github.com
+
+# Jenkins pipeline trigger secret (raw)
+PIPELINE_TRIGGER_SECRET=changeme

--- a/ods-provisioning-app/ocp-config/prov-dev/cm.env.sample
+++ b/ods-provisioning-app/ocp-config/prov-dev/cm.env.sample
@@ -52,5 +52,5 @@ MAIL_USERNAME=provision
 LOG_LEVEL_ATLASSIAN_CROWD=DEBUG
 LOG_LEVEL_OPENDEVSTACK=DEBUG
 
-# Jenkins pipeline trigger secret
+# Jenkins pipeline trigger secret (raw)
 PIPELINE_TRIGGER_SECRET=changeme

--- a/ods-provisioning-app/ocp-config/prov-test/cm.env.sample
+++ b/ods-provisioning-app/ocp-config/prov-test/cm.env.sample
@@ -51,5 +51,5 @@ MAIL_USERNAME=provision
 LOG_LEVEL_ATLASSIAN_CROWD=INFO
 LOG_LEVEL_OPENDEVSTACK=INFO
 
-# Jenkins pipeline trigger secret
+# Jenkins pipeline trigger secret (raw)
 PIPELINE_TRIGGER_SECRET=changeme


### PR DESCRIPTION
To ease setup, we seed the production pipeline of the provisioning app,
and for this we need some params.

Relates to
https://github.com/opendevstack/ods-provisioning-app/issues/68.